### PR TITLE
Mark Environment with Sync cause it's thread-safe.

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -559,6 +559,9 @@ pub struct Environment {
     db_cache: Mutex<UnsafeCell<HashMap<String, ffi::MDB_dbi>>>,
 }
 
+// It can be used from multiple threads.
+unsafe impl Sync for Environment {}
+
 #[unstable]
 impl Environment {
     pub fn new() -> EnvBuilder {


### PR DESCRIPTION
Need this one to use LMDB with https://github.com/Kimundi/lazy-static.rs.