### PR TITLE
Derive MdbError from Debug

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -112,6 +112,7 @@ macro_rules! assert_state_not {
 /// MdbError wraps information about LMDB error
 
 #[unstable]
+#[derive(Debug)]
 pub enum MdbError {
     NotFound,
     KeyExists,


### PR DESCRIPTION
Everything should derive from Debug. It's also useful for `Result::unwrap` in unit tests.