### PR TITLE
Provide access to the `mdb_reader_check`.

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -584,6 +584,14 @@ impl Environment {
         }
     }
 
+    /// Check for stale entries in the reader lock table.
+    ///
+    /// Returns the number of stale slots that were cleared.
+    pub fn reader_check(&self) -> MdbResult<c_int> {
+        let mut dead: c_int = 0;
+        lift_mdb!(unsafe { ffi::mdb_reader_check(self.env, &mut dead as *mut c_int)}, dead)
+    }
+
     pub fn stat(&self) -> MdbResult<ffi::MDB_stat> {
         let mut tmp: ffi::MDB_stat = unsafe { std::mem::zeroed() };
         lift_mdb!(unsafe { ffi::mdb_env_stat(self.env.0, &mut tmp)}, tmp)


### PR DESCRIPTION
This method should be called periodically to ensure that the crashed readers are removed from the lock table.
cf. the caveats at http://symas.com/mdb/doc/index.html