### PR TITLE
Add support for setting compare and dupsort functions

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -497,6 +497,25 @@ impl<'a> Database<'a> {
         let inner_iter = CursorItemIter::<'c>::new(key);
         Ok(CursorIterator::<'c>::wrap(cursor, inner_iter))
     }
+
+    /// Sets the compare function for this database.
+    ///
+    /// Setting lasts for the lifetime of the underlying db handle.
+    pub fn set_compare(&self, cmp_fn: extern "C" fn(*const MDB_val, *const MDB_val) -> c_int) -> MdbResult<()> {
+        lift_mdb!(unsafe {
+            ffi::mdb_set_compare(self.txn.handle, self.handle, cmp_fn)
+        })
+    }
+
+    /// Sets the value comparison function for values of the same key in this database.
+    ///
+    /// Only makes sense when DbAllowDups is true.
+    /// Setting lasts for the lifetime of the underlying db handle.
+    pub fn set_dupsort(&self, cmp_fn: extern "C" fn(*const MDB_val, *const MDB_val) -> c_int) -> MdbResult<()> {
+        lift_mdb!(unsafe {
+            ffi::mdb_set_dupsort(self.txn.handle, self.handle, cmp_fn)
+        })
+    }
 }
 
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -498,7 +498,15 @@ impl<'a> Database<'a> {
         Ok(CursorIterator::<'c>::wrap(cursor, inner_iter))
     }
 
-    /// Sets the compare function for this database.
+    /// Sets the key compare function for this database.
+    ///
+    /// Warning: This function must be called before any data access functions
+    /// are used, otherwise data corruption may occur. The same comparison
+    /// function must be used by every program accessing the database, every
+    /// time the database is used.
+    ///
+    /// If not called, keys are compared lexically, with shorter keys collating
+    /// before longer keys.
     ///
     /// Setting lasts for the lifetime of the underlying db handle.
     pub fn set_compare(&self, cmp_fn: extern "C" fn(*const MDB_val, *const MDB_val) -> c_int) -> MdbResult<()> {
@@ -509,7 +517,15 @@ impl<'a> Database<'a> {
 
     /// Sets the value comparison function for values of the same key in this database.
     ///
-    /// Only makes sense when DbAllowDups is true.
+    /// Warning: This function must be called before any data access functions
+    /// are used, otherwise data corruption may occur. The same dupsort
+    /// function must be used by every program accessing the database, every
+    /// time the database is used.
+    ///
+    /// If not called, values are compared lexically, with shorter values collating
+    /// before longer values.
+    ///
+    /// Only used when DbAllowDups is true.
     /// Setting lasts for the lifetime of the underlying db handle.
     pub fn set_dupsort(&self, cmp_fn: extern "C" fn(*const MDB_val, *const MDB_val) -> c_int) -> MdbResult<()> {
         lift_mdb!(unsafe {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -719,15 +719,8 @@ fn test_compare() {
     let txn = env.new_transaction().unwrap();
     {
         let db = txn.bind(&db_handle);
-        let mut cursor = db.new_cursor().unwrap();
-        assert!(cursor.to_first().is_ok());
-
-        let first_key = cursor.get_key::<i32>().unwrap();
-        assert!(first_key == 5);
-
-        assert!(cursor.to_next_key().is_ok());
-        let second_key = cursor.get_key::<i32>().unwrap();
-        assert!(second_key == 3);
+        let keys: Vec<_> = db.iter().unwrap().map(|cv| cv.get_key::<i32>()).collect();
+        assert_eq!(keys, [5, 3, 2, 4]);
     }
     assert!(txn.commit().is_ok());
 }
@@ -762,15 +755,8 @@ fn test_dupsort() {
     let txn = env.new_transaction().unwrap();
     {
         let db = txn.bind(&db_handle);
-        let mut cursor = db.new_cursor().unwrap();
-        assert!(cursor.to_first().is_ok());
-
-        let first_val = cursor.get_value::<i32>().unwrap();
-        assert!(first_val == 5);
-
-        assert!(cursor.to_next_item().is_ok());
-        let second_val = cursor.get_value::<i32>().unwrap();
-        assert!(second_val == 3);
+        let vals: Vec<_> = db.item_iter(&key).unwrap().map(|cv| cv.get_value::<i32>()).collect();
+        assert_eq!(vals, [5, 3, 2, 4]);
     }
     assert!(txn.commit().is_ok());
 }


### PR DESCRIPTION
This is a bit icky since it exposes the ffi function header, but since lmdb doesn't pass a void* to the comparison function, I couldn't think of a good way to set up a wrapper function. I guess we could do a macro, but seems like that'd probably be more confusing than just needing to interact with the ffi layer. Thoughts?