### PR TITLE
Make three Database methods use dynamic dispatch

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -411,17 +411,17 @@ impl<'a> Database<'a> {
     }
 
     /// Sets value for key. In case of DbAllowDups it will add a new item
-    pub fn set<K: ToMdbValue, V: ToMdbValue>(&self, key: &K, value: &V) -> MdbResult<()> {
+    pub fn set(&self, key: &ToMdbValue, value: &ToMdbValue) -> MdbResult<()> {
         self.txn.set(self.handle, key, value)
     }
 
     /// Set value for key. Fails if key already exists, even when duplicates are allowed.
-    pub fn insert<K: ToMdbValue, V: ToMdbValue>(&self, key: &K, value: &V) -> MdbResult<()> {
+    pub fn insert(&self, key: &ToMdbValue, value: &ToMdbValue) -> MdbResult<()> {
         self.txn.insert(self.handle, key, value)
     }
 
     /// Deletes value for key.
-    pub fn del<K: ToMdbValue>(&self, key: &K) -> MdbResult<()> {
+    pub fn del(&self, key: &ToMdbValue) -> MdbResult<()> {
         self.txn.del(self.handle, key)
     }
 


### PR DESCRIPTION
These methods are all thin wrappers around NativeTransaction methods that use dynamic dispatch so monomorphizing is probably a pessimization anyhow, and this lets these functions be called with dynamic dispatch (in our case we'd like to call the function with one of a variety of ToMdbValue concrete implementations, determined at runtime).