### PR TITLE
Generic sort functions to be used with set_dupsort() or set_compare().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use core::{Database, DbFlags, DbHandle};
 pub use core::{Transaction, ReadonlyTransaction, MdbError, MdbValue};
 pub use core::{Cursor, CursorValue, CursorIter, CursorKeyRangeIter};
 pub use traits::{FromMdbValue, ToMdbValue};
+pub use utils::{sort, sort_reverse};
 
 pub mod core;
 pub mod traits;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ use std::mem;
 use super::{FromMdbValue, MdbValue};
 use ffi::MDB_val;
 use ffi::mdb_strerror;
+use std::cmp::Ordering;
 
 pub fn error_msg(code: c_int) -> String {
     unsafe {
@@ -11,17 +12,27 @@ pub fn error_msg(code: c_int) -> String {
     }
 }
 
+#[inline(always)]
+fn order_to_c_int(ord: Ordering) -> c_int {
+    let order: i8 = unsafe { mem::transmute(ord) };
+    order as c_int
+}
+
 pub extern "C" fn sort<T:FromMdbValue+Ord>(lhs_val: *const MDB_val, rhs_val: *const MDB_val) -> c_int {
     let lhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(lhs_val)});
     let rhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(rhs_val)});
-
-    let order: i8 = unsafe { mem::transmute(lhs.cmp(&rhs)) };
-    order as c_int
+    order_to_c_int(lhs.cmp(&rhs))
 }
 
 pub extern "C" fn sort_reverse<T:FromMdbValue+Ord>(lhs_val: *const MDB_val, rhs_val: *const MDB_val) -> c_int {
     let lhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(lhs_val)});
     let rhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(rhs_val)});
-    let order: i8 = unsafe { mem::transmute(lhs.cmp(&rhs).reverse()) };
-    order as c_int
+    order_to_c_int(lhs.cmp(&rhs).reverse())
+}
+
+#[test]
+fn test_order() {
+    assert!(order_to_c_int(Ordering::Less) < 0);
+    assert!(order_to_c_int(Ordering::Equal) == 0);
+    assert!(order_to_c_int(Ordering::Greater) > 0);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,27 @@
 use libc::c_int;
 use std::ffi::{CStr};
-
+use std::mem;
+use super::{FromMdbValue, MdbValue};
+use ffi::MDB_val;
 use ffi::mdb_strerror;
 
 pub fn error_msg(code: c_int) -> String {
     unsafe {
         String::from_utf8(CStr::from_ptr(mdb_strerror(code)).to_bytes().to_vec()).unwrap()
     }
+}
+
+pub extern "C" fn sort<T:FromMdbValue+Ord>(lhs_val: *const MDB_val, rhs_val: *const MDB_val) -> c_int {
+    let lhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(lhs_val)});
+    let rhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(rhs_val)});
+
+    let order: i8 = unsafe { mem::transmute(lhs.cmp(&rhs)) };
+    order as c_int
+}
+
+pub extern "C" fn sort_reverse<T:FromMdbValue+Ord>(lhs_val: *const MDB_val, rhs_val: *const MDB_val) -> c_int {
+    let lhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(lhs_val)});
+    let rhs = T::from_mdb_value(&unsafe{MdbValue::from_raw(rhs_val)});
+    let order: i8 = unsafe { mem::transmute(lhs.cmp(&rhs).reverse()) };
+    order as c_int
 }


### PR DESCRIPTION
Use it like this (for every type that implement FromMdbValue and Ord):

```
db.set_compare(lmdb::sort::<u64>);
db.set_dupsort(lmdb::sort_reverse::<u64>);
```
