### PR TITLE
Drop dependency on the regex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,4 @@ version = "0.2.1"
 [dependencies]
 log = "0.3"
 libc = "0.2"
-regex = "0.1"
 bitflags = "0.7"


### PR DESCRIPTION
* seem to be something forgotten from earlier times.
* avoids having to compile the regex crate in projects when not needed.