### PR TITLE
api: Use AsRef<Path> instead of &Path

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,11 +1,9 @@
 extern crate lmdb_rs as lmdb;
 
-use std::path::Path;
 use lmdb::{EnvBuilder, DbFlags};
 
 fn main() {
-    let path = Path::new("test-lmdb");
-    let env = EnvBuilder::new().open(&path, 0o777).unwrap();
+    let env = EnvBuilder::new().open("test-lmdb", 0o777).unwrap();
 
     let db_handle = env.get_default_db(DbFlags::empty()).unwrap();
     let txn = env.new_transaction().unwrap();


### PR DESCRIPTION
This matches the convention used in std and makes the API simpler
when calling open() as you can just provide a &str or String and
it will be converted into a &Path autmmatically.  This change is
backwards compatible, so a full semver bump should not be required.

You can see this pattern in std in a number of places:
* https://doc.rust-lang.org/std/fs/struct.File.html#method.open
* https://doc.rust-lang.org/std/fs/fn.read_dir.html
* ... (basically everything that uses a path) ...