### PR TITLE
Bump minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmdb-rs"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Valerii Hiora <valerii.hiora@gmail.com>"]
 license = "MIT"
 description = "LMDB bindings"


### PR DESCRIPTION
Update minor version so that the artifact published on [crates.io](https://crates.io/crates/lmdb-rs) compiles correctly.