### PR TITLE
fix double free after commit failure

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -986,12 +986,12 @@ impl<'a> NativeTransaction<'a> {
     fn commit(&mut self) -> MdbResult<()> {
         assert_state_eq!(txn, self.state, TransactionState::Normal);
         debug!("commit txn");
-        try_mdb!(unsafe { ffi::mdb_txn_commit(self.handle) } );
         self.state = if self.is_readonly() {
             TransactionState::Released
         } else {
             TransactionState::Invalid
         };
+        try_mdb!(unsafe { ffi::mdb_txn_commit(self.handle) } );
         Ok(())
     }
 


### PR DESCRIPTION
in commit() function call to ffi::mdb_txn_commit() should be after state change.
mdb_txn_commit() will free handle even in failure case. But TransactionState would be still ‘Nomral’ if call fails and is done before state change. Dropping transaction would then cause silent_abort() to call mdb_txn_abort() and free handle again. 