### PR TITLE
wrapper for mdb_env_set_mapsize

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -746,6 +746,12 @@ impl Environment {
         lift_mdb!(unsafe { ffi::mdb_env_sync(self.env.0, if force {1} else {0})})
     }
 
+    /// Sets map size.
+    /// This can be called after [open](struct.EnvBuilder.html#method.open) if no transactions are active in this process.
+    pub fn set_mapsize(&self, map_size: usize) -> MdbResult<()> {
+        lift_mdb!(unsafe { ffi::mdb_env_set_mapsize(self.env.0, map_size as size_t)})
+    }
+
     /// This one sets only flags which are available for change even
     /// after opening, see also [get_flags](#method.get_flags) and [get_all_flags](#method.get_all_flags)
     pub fn set_flags(&mut self, flags: EnvFlags, turn_on: bool) -> MdbResult<()> {


### PR DESCRIPTION
If running into MDB_MAP_FULL error it would be nice to have option to resize map without need to re-create environment. As long as no active transaction is open, call to mdb_env_set_mapsize() would allow resizing on open environment.
I added wrapper method to Environment plus a test.
Tested in my project resizing multiple times with a couple of MB of data.