### PR TITLE
Read-only and read-write Database and Transaction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ extern crate liblmdb_sys as ffi;
 pub use libc::c_int;
 pub use ffi::{mdb_filehandle_t, MDB_stat, MDB_envinfo, MDB_val};
 pub use core::{EnvBuilder, Environment, EnvFlags, EnvCreateFlags};
-pub use core::{Database, DbFlags, DbHandle};
-pub use core::{Transaction, ReadonlyTransaction, MdbError, MdbValue};
+pub use core::{Database, ReadOnlyDatabase, ReadWriteDatabase, DbFlags, DbHandle};
+pub use core::{Transaction, ReadOnlyTransaction, ReadWriteTransaction, MdbError, MdbValue};
 pub use core::{Cursor, CursorValue, CursorIter, CursorKeyRangeIter};
 pub use traits::{FromMdbValue, ToMdbValue};
 


### PR DESCRIPTION
This commit unifies the `Transaction` and `ReadonlyTransaction` types
into a single `Transaction` type that is generic with respect to whether
the transaction is read-only or read-write. There are two new type
definitions, `ReadOnlyTransaction` and `ReadWriteTransaction`, which
should provide some syntactic sugar for applications.

Similarly, this commit changes the `Database` type to be generic with
respect to read-only vs read-write access, as well as creating two new
type definitions, `ReadOnlyDatabase` and `ReadWriteDatabase`. Read-only
databases only provide non-mutating methods. For example, it will be a
compiler error for an application to call the `put` method on a
`ReadOnlyDatabase`.