### PR TITLE
Added new trait instances for `ToMdbValue`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,6 +59,7 @@ impl<'a> ToMdbValue for &'a str {
         }
     }
 }
+
 impl ToMdbValue for str {
     fn to_mdb_value<'a>(&'a self) -> MdbValue<'a> {
         unsafe {
@@ -69,6 +70,15 @@ impl ToMdbValue for str {
 }
 
 impl<'a> ToMdbValue for &'a [u8] {
+    fn to_mdb_value<'b>(&'b self) -> MdbValue<'b> {
+        unsafe {
+            MdbValue::new(std::mem::transmute(self.as_ptr()),
+                          self.len())
+        }
+    }
+}
+
+impl ToMdbValue for [u8] {
     fn to_mdb_value<'b>(&'b self) -> MdbValue<'b> {
         unsafe {
             MdbValue::new(std::mem::transmute(self.as_ptr()),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,6 +59,14 @@ impl<'a> ToMdbValue for &'a str {
         }
     }
 }
+impl ToMdbValue for str {
+    fn to_mdb_value<'a>(&'a self) -> MdbValue<'a> {
+        unsafe {
+            MdbValue::new(mem::transmute(self.as_ptr()),
+                          self.len())
+        }
+    }
+}
 
 impl<'a> ToMdbValue for &'a [u8] {
     fn to_mdb_value<'b>(&'b self) -> MdbValue<'b> {


### PR DESCRIPTION
It is rather painful to write a trait which abstracts over types.

The use case I'm attempting to fix is:

```
trait ApplicationDBs {
  type Key: ToMdbValue;
  type Protobuffer: Message+MessageStatic;
  fn get_db_handle<'a>(&'a self) -> &'a DbHandle;
}
trait CommonDBActions: DBTrans {
   type Key: ToMdbValue;
   type ProtoBuffer: Message+MessageStatic;
   //library boiler plate
}
impl<T: ApplicationDB> CommonDBAction for MyType {
   type Key = T::Key;
   type ProtoBuffer = T::ProtoBuffer;
}
```

This works great for integers + protobuffers. But I have to expand to strings, byte arrays. 