### PR TITLE
Added `ToMdbValue` implementations

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,6 +59,7 @@ impl<'a> ToMdbValue for &'a str {
         }
     }
 }
+
 impl ToMdbValue for str {
     fn to_mdb_value<'a>(&'a self) -> MdbValue<'a> {
         unsafe {
@@ -69,6 +70,15 @@ impl ToMdbValue for str {
 }
 
 impl<'a> ToMdbValue for &'a [u8] {
+    fn to_mdb_value<'b>(&'b self) -> MdbValue<'b> {
+        unsafe {
+            MdbValue::new(std::mem::transmute(self.as_ptr()),
+                          self.len())
+        }
+    }
+}
+
+impl ToMdbValue for [u8] {
     fn to_mdb_value<'b>(&'b self) -> MdbValue<'b> {
         unsafe {
             MdbValue::new(std::mem::transmute(self.as_ptr()),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,6 +59,14 @@ impl<'a> ToMdbValue for &'a str {
         }
     }
 }
+impl ToMdbValue for str {
+    fn to_mdb_value<'a>(&'a self) -> MdbValue<'a> {
+        unsafe {
+            MdbValue::new(mem::transmute(self.as_ptr()),
+                          self.len())
+        }
+    }
+}
 
 impl<'a> ToMdbValue for &'a [u8] {
     fn to_mdb_value<'b>(&'b self) -> MdbValue<'b> {


### PR DESCRIPTION
### Changes

Added 2 new implementations of `ToMdbValue` for `str` and `[u8]` (the non-sized versions without pointers). 

### Goals

Makes it easier to implement traits like 

```rust
pub trait GenericLMDBCursor<ActualDBData> {
   type Key: ActualDBData::Key+?Sized;
   type Value: ActualDBData::Value;
   // methods..
}
pub trait ActualDBData {
  type Key: ToMdbValue+?Sized;
  type Value: Message+MessageStatic; //protobuffers
  fn get_db_handle<'a>() -> &'a Database;
}
pub struct DocDB;
impl ActualDBData {
  type Key = str;
  type Value = DocProto;
  fn get_db_handle<'a>() -> &'a Database {
        get_cached_doc_handle()
   }
}
```

Effectively then I just have one fat trait that does all db stuff on abstract data. And a handful of ZeroSizedTypes which tell me what data I'm using. 