### PR TITLE
Switch gcc crate to cc crate

### DIFF
--- a/liblmdb-sys/Cargo.toml
+++ b/liblmdb-sys/Cargo.toml
@@ -11,4 +11,4 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/liblmdb-sys/build.rs
+++ b/liblmdb-sys/build.rs
@@ -1,9 +1,9 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
     let target = std::env::var("TARGET").unwrap();
 
-    let mut config = gcc::Config::new();
+    let mut config = cc::Build::new();
     config.file("mdb/libraries/liblmdb/mdb.c")
           .file("mdb/libraries/liblmdb/midl.c");
     config.opt_level(2);


### PR DESCRIPTION
It was renamed, and has published a stable 1.0 release.