### PR TITLE
Add OpenBSD support

### DIFF
--- a/liblmdb-sys/src/lib.rs
+++ b/liblmdb-sys/src/lib.rs
@@ -7,7 +7,7 @@ use libc::{c_int, c_uint, c_void, c_char, size_t};
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "linux",
           target_os = "freebsd", target_os = "dragonfly",
-          target_os = "android"))]
+          target_os = "android", target_os = "openbsd"))]
 mod os {
     use libc;
 


### PR DESCRIPTION
This PR allows lmdb-rs to be built on OpenBSD systems. Without this update, compiling on OpenBSD fails with `error[E0432]: unresolved import self::os`