### PR TITLE
refactor(liblmdb-sys): use cc crate instead of gcc

### DIFF
--- a/liblmdb-sys/Cargo.toml
+++ b/liblmdb-sys/Cargo.toml
@@ -11,4 +11,4 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/liblmdb-sys/build.rs
+++ b/liblmdb-sys/build.rs
@@ -1,9 +1,9 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
     let target = std::env::var("TARGET").unwrap();
 
-    let mut config = gcc::Config::new();
+    let mut config = cc::Build::new();
     config.file("mdb/libraries/liblmdb/mdb.c")
           .file("mdb/libraries/liblmdb/midl.c");
     config.opt_level(2);


### PR DESCRIPTION
cc crate uses the native C compiler to compile C sources. Since gcc has been removed from android ndk, this commit helps to have a seamless compilation for android with cargo build.