### PR TITLE
Update to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmdb-rs"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["Valerii Hiora <valerii.hiora@gmail.com>"]
 license = "MIT"
 description = "LMDB bindings"
@@ -13,12 +13,13 @@ exclude = [
         ".travis.yml",
         "up_doc.sh",
 ]
+edition = "2018"
 
 [dependencies.liblmdb-sys]
 path = "liblmdb-sys"
 version = "0.2.2"
 
 [dependencies]
-log = "0.3"
+log = "0.4"
 libc = "0.2"
-bitflags = "0.7"
+bitflags = "1.3"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,4 @@
-extern crate lmdb_rs as lmdb;
-
-use lmdb::{EnvBuilder, DbFlags};
+use lmdb_rs::{DbFlags, EnvBuilder};
 
 fn main() {
     let env = EnvBuilder::new().open("test-lmdb", 0o777).unwrap();
@@ -10,9 +8,11 @@ fn main() {
     {
         let db = txn.bind(&db_handle); // get a database bound to this transaction
 
-        let pairs = vec![("Albert", "Einstein",),
-                         ("Joe", "Smith",),
-                         ("Jack", "Daniels")];
+        let pairs = vec![
+            ("Albert", "Einstein"),
+            ("Joe", "Smith"),
+            ("Jack", "Daniels"),
+        ];
 
         for &(name, surname) in pairs.iter() {
             db.set(&surname, &name).unwrap();
@@ -24,7 +24,7 @@ fn main() {
     // the client to handle the error
     match txn.commit() {
         Err(_) => panic!("failed to commit!"),
-        Ok(_) => ()
+        Ok(_) => (),
     }
 
     let reader = env.get_reader().unwrap();

--- a/liblmdb-sys/Cargo.toml
+++ b/liblmdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liblmdb-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Valerii Hiora <valerii.hiora@gmail.com>"]
 links = "lmdb"
 license = "MIT"
@@ -11,4 +11,4 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/liblmdb-sys/Cargo.toml
+++ b/liblmdb-sys/Cargo.toml
@@ -7,8 +7,10 @@ license = "MIT"
 description = "LMDB native lib"
 repository = "https://github.com/vhbit/lmdb-rs"
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 libc = "0.2"
+
 [build-dependencies]
 cc = "1.0"

--- a/liblmdb-sys/build.rs
+++ b/liblmdb-sys/build.rs
@@ -1,5 +1,3 @@
-extern crate cc;
-
 fn main() {
     let target = std::env::var("TARGET").unwrap();
 

--- a/liblmdb-sys/build.rs
+++ b/liblmdb-sys/build.rs
@@ -1,12 +1,14 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
     let target = std::env::var("TARGET").unwrap();
 
-    let mut config = gcc::Config::new();
+    let mut config = cc::Build::new();
     config.file("mdb/libraries/liblmdb/mdb.c")
           .file("mdb/libraries/liblmdb/midl.c");
     config.opt_level(2);
+    config.flag("-Wno-unused-parameter");
+    config.flag("-Wno-implicit-fallthrough");
 
     if target.contains("dragonfly") {
         config.flag("-DMDB_DSYNC=O_SYNC");

--- a/liblmdb-sys/src/lib.rs
+++ b/liblmdb-sys/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code, non_camel_case_types)]
 
-extern crate libc;
-
 pub use self::os::{mdb_mode_t, mdb_filehandle_t};
 use libc::{c_int, c_uint, c_void, c_char, size_t};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,12 @@
 #![allow(trivial_casts)]
 #![allow(trivial_numeric_casts)]
 
-extern crate libc;
-
-#[macro_use] extern crate bitflags;
-#[macro_use] extern crate log;
-
-extern crate liblmdb_sys as ffi;
-
+pub use crate::core::{
+    Cursor, CursorIter, CursorKeyRangeIter, CursorValue, Database, DbFlags, DbHandle, EnvBuilder,
+    EnvCreateFlags, EnvFlags, Environment, MdbError, MdbValue, ReadonlyTransaction, Transaction,
+};
 pub use libc::c_int;
-pub use ffi::{mdb_filehandle_t, MDB_stat, MDB_envinfo, MDB_val};
-pub use core::{EnvBuilder, Environment, EnvFlags, EnvCreateFlags};
-pub use core::{Database, DbFlags, DbHandle};
-pub use core::{Transaction, ReadonlyTransaction, MdbError, MdbValue};
-pub use core::{Cursor, CursorValue, CursorIter, CursorKeyRangeIter};
+pub use liblmdb_sys::{mdb_filehandle_t, MDB_envinfo, MDB_stat, MDB_val};
 pub use traits::{FromMdbValue, ToMdbValue};
 
 pub mod core;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,7 @@
 use libc::c_int;
-use std::ffi::{CStr};
-
-use ffi::mdb_strerror;
+use liblmdb_sys::mdb_strerror;
+use std::ffi::CStr;
 
 pub fn error_msg(code: c_int) -> String {
-    unsafe {
-        String::from_utf8(CStr::from_ptr(mdb_strerror(code)).to_bytes().to_vec()).unwrap()
-    }
+    unsafe { String::from_utf8(CStr::from_ptr(mdb_strerror(code)).to_bytes().to_vec()).unwrap() }
 }


### PR DESCRIPTION
* liblmdb-sys: use `cc` instead if the deprecated `gcc` crate.
* liblmdb-sys: suppress innocuous compiler warnings from `mdb`
* lmdb-rs: update `bitflags` to version 1.3 with name-spacing [breaking change]
* lmdb-rs: update `log` to version 0.4
* lmdb-rs: replace `try!` macro usage with the `?` operator
* lmdb-rs: update to Rust 2018 edition and address all clippy warnings
